### PR TITLE
fix: opt in to `import.meta.*` properties

### DIFF
--- a/docs/content/1.getting-started/2.configuration.md
+++ b/docs/content/1.getting-started/2.configuration.md
@@ -70,7 +70,7 @@ component is rendered, you must manually initialize the tsParticles library (suc
 import { tsParticles } from '@tsparticles/engine'
 import { loadFull } from 'tsparticles' // or whichever bundle you wish to use
 
-if (process.client) {
+if (import.meta.client) {
   // This example will BLOCK your application from rendering until the tsParticles library is initialized
   // You can put this in some other place if you know that you won't be loading particles until after the first paint
   await loadFull(tsParticles)

--- a/playground/app.vue
+++ b/playground/app.vue
@@ -26,7 +26,7 @@ const { mode } = useRuntimeConfig().public.particles
 
 const show = ref(false)
 
-if(process.client && mode === 'custom') {
+if(import.meta.client && mode === 'custom') {
   await loadFull(tsParticles)
 }
 

--- a/src/runtime/plugins/particle-loader.client.ts
+++ b/src/runtime/plugins/particle-loader.client.ts
@@ -3,7 +3,7 @@ import { loadParticles } from '../lib/loaders'
 import { tsParticles} from 'tsparticles-engine'
 
 export default defineNuxtPlugin(async (nuxtApp) => {
-  if(process.server) { return }
+  if(import.meta.server) { return }
 
   const runtimeConfig = useRuntimeConfig()
   const { mode } = runtimeConfig.public.particles


### PR DESCRIPTION
This is a very early PR to make this module compatible with [changes we expect to release in Nuxt v5](https://github.com/nuxt/nuxt/issues/25323).

In [Nuxt v3.7.0](https://github.com/nuxt/nuxt/releases/tag/v3.7.0) we added support for `import.meta.*` (see [original PR](https://github.com/nuxt/nuxt/pull/22428)) and we've been gradually updating docs and moving across from the old `process.*` patterned variables.

As I'm sure you're aware, these variables are replaced at build-time and enable tree-shaking in bundled code.
This change affects _runtime_ code (that is, that is processed by the Nuxt bundler, like vite or webpack) rather than code running in Node. So it really doesn't matter what the string is, but it makes more sense in an ESM-world to use `import.meta` rather than `process`.

(It might be worth updating the module compatibility as well to indicate it needs to have Nuxt v3.7.0+, but I'll leave that with you if you think this is a good approach.)