### PR TITLE
docs: use new `nuxi module add` command in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,7 @@ Run lightweight, heavily customizable particle simulations in your Nuxt project 
 1. Add the `nuxt-particles` dependency to your project
 
 ```bash
-# Using pnpm
-pnpm add -D nuxt-particles
-
-# Using yarn
-yarn add --dev nuxt-particles
-
-# Using npm
-npm install --save-dev nuxt-particles
+npx nuxi@latest module add particles
 ```
 
 2. Add `nuxt-particles` to the `modules` section of `nuxt.config.ts`

--- a/docs/content/0.index.md
+++ b/docs/content/0.index.md
@@ -37,7 +37,7 @@ Run lightweight, heavily customizable particle simulations in your Nuxt project 
   ::terminal
   ---
   content:
-  - pnpm i -D nuxt-particles
+  - npx nuxi@latest module add particles
   - Add 'nuxt-particles' to your 'modules' array in 'nuxt.config.ts'
   - Profit!
   ---

--- a/docs/content/1.getting-started/1.setup.md
+++ b/docs/content/1.getting-started/1.setup.md
@@ -5,22 +5,9 @@ This module is plug-and-play with sensible defaults. Just install the package to
 ## Installation
 
 1. Install the `nuxt-particles` package:
-
-::code-group
-
-  ```bash [pnpm]
-  pnpm add -D nuxt-particles
-  ```
-
-  ```bash [yarn]
-  yarn add -D nuxt-particles
-  ```
-
-  ```bash [npm]
-  npm install --save-dev nuxt-particles
-  ```
-
-::
+```bash
+npx nuxi@latest module add particles
+```
 
 2. Add the `nuxt-particles` package to the `modules` array in your `nuxt.config.ts`:
 


### PR DESCRIPTION

This updates the documentation to use the [`nuxi module add` command](https://github.com/nuxt/cli/pull/197) which should simplify docs a bit and also improve user experience as there's no need to add to `nuxt.config` manually.

It's documented [here](https://nuxt.com/docs/api/commands/module#nuxi-module-add).

I may have missed a few spots in the documentation as I'm doing this across the modules ecosystem assisted by the power of regular expressions ✨, so I'd appreciate a review 🙏
